### PR TITLE
docs(example): add channel example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-channel"
+version = "0.1.1"
+dependencies = [
+ "async-watcher",
+ "tokio",
+]
+
+[[package]]
 name = "example-rebuild"
 version = "0.1.1"
 dependencies = [

--- a/examples/channel/Cargo.toml
+++ b/examples/channel/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example-channel"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+async-watcher = { path = "../../crates/watcher" }
+tokio = { workspace = true }

--- a/examples/channel/src/main.rs
+++ b/examples/channel/src/main.rs
@@ -1,0 +1,43 @@
+use async_watcher::{
+    notify::{self, RecommendedWatcher, RecursiveMode},
+    AsyncDebouncer, DebouncedEvent,
+};
+use std::{path::Path, time::Duration};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let paths = vec!["Cargo.toml", "Cargo.lock", "crates", "examples"];
+
+    let (mut file_events, _debouncer) = async_debounce_watch(paths).await?;
+
+    while let Some(event) = file_events.recv().await {
+        println!("event: {:?}", event);
+    }
+
+    Ok(())
+}
+
+pub async fn async_debounce_watch<P: AsRef<Path>>(
+    paths: Vec<P>,
+) -> Result<
+    (
+        tokio::sync::mpsc::Receiver<Result<Vec<DebouncedEvent>, Vec<notify::Error>>>,
+        AsyncDebouncer<RecommendedWatcher>,
+    ),
+    Box<dyn std::error::Error>,
+> {
+    let (tx, rx) = tokio::sync::mpsc::channel(100);
+
+    let mut debouncer =
+        AsyncDebouncer::new(Duration::from_secs(1), Some(Duration::from_secs(1)), tx).await?;
+
+    // add the paths to the watcher
+    paths.iter().for_each(|p| {
+        debouncer
+            .watcher()
+            .watch(p.as_ref(), RecursiveMode::Recursive)
+            .unwrap();
+    });
+
+    Ok((rx, debouncer))
+}


### PR DESCRIPTION
This example utilizes a tokio::sync::mpsc::channel for communicating events. This has the benefit of vastly simplifying code: no application logic has to exist inside of the `async_debounce_watch` function. Instead, the debouncer is kept in scope because the function returns it as well as the receiver used to retrieve events.