### PR TITLE
Add functions that use channels

### DIFF
--- a/examples/rebuild/src/main.rs
+++ b/examples/rebuild/src/main.rs
@@ -1,24 +1,14 @@
-use std::{path::Path, time::Duration};
-
 use async_watcher::{notify::RecursiveMode, AsyncDebouncer};
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (mut debouncer, mut file_events) =
+        AsyncDebouncer::new_with_channel(Duration::from_secs(1), Some(Duration::from_secs(1)))
+            .await?;
+
+    // register the paths to be watched
     let paths = vec!["Cargo.toml", "Cargo.lock", "crates", "examples"];
-
-    async_debounce_watch(paths).await?;
-
-    Ok(())
-}
-
-pub async fn async_debounce_watch<P: AsRef<Path>>(
-    paths: Vec<P>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
-
-    let mut debouncer =
-        AsyncDebouncer::new(Duration::from_secs(1), Some(Duration::from_secs(1)), tx).await?;
-
     paths.iter().for_each(|p| {
         debouncer
             .watcher()
@@ -29,7 +19,7 @@ pub async fn async_debounce_watch<P: AsRef<Path>>(
     // keep track of the child process so we can kill it later
     let mut build_process: Option<tokio::process::Child> = None;
 
-    while let Some(event) = rx.recv().await {
+    while let Some(event) = file_events.recv().await {
         match event {
             Ok(_events) => {
                 // for this example we are triggering on any event, so we are not checking the info

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,24 +1,15 @@
-use std::{path::Path, time::Duration};
-
 use async_watcher::{notify::RecursiveMode, AsyncDebouncer};
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // initialize the debouncer
+    let (mut debouncer, mut file_events) =
+        AsyncDebouncer::new_with_channel(Duration::from_secs(1), Some(Duration::from_secs(1)))
+            .await?;
+
+    // register the paths to be watched
     let paths = vec!["Cargo.toml", "Cargo.lock", "crates", "examples"];
-
-    async_debounce_watch(paths).await?;
-
-    Ok(())
-}
-
-pub async fn async_debounce_watch<P: AsRef<Path>>(
-    paths: Vec<P>,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let (tx, mut rx) = tokio::sync::mpsc::channel(100);
-
-    let mut debouncer =
-        AsyncDebouncer::new(Duration::from_secs(1), Some(Duration::from_secs(1)), tx).await?;
-
     paths.iter().for_each(|p| {
         debouncer
             .watcher()
@@ -26,17 +17,9 @@ pub async fn async_debounce_watch<P: AsRef<Path>>(
             .unwrap();
     });
 
-    while let Some(event) = rx.recv().await {
-        match event {
-            Ok(events) => {
-                events.iter().for_each(|e| println!("event: {:?}", e));
-            }
-            Err(errors) => {
-                for error in errors {
-                    println!("error: {error:?}");
-                }
-            }
-        }
+    // wait for events
+    while let Some(event) = file_events.recv().await {
+        println!("event: {:?}", event);
     }
 
     Ok(())


### PR DESCRIPTION
This simplifies the logic that I've been having to add in consumer crates. The simple example is much cleaner. All previous functionality remains as is.