### PR TITLE
refactor(cli): vastly simplify child process logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tracing",
  "tracing-subscriber",
 ]
@@ -428,12 +427,6 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "gimli"
@@ -869,19 +862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,6 @@ async-watcher = { path = "../watcher" }
 globset = "0.4"
 thiserror.workspace = true
 tokio-stream = { version = "0.1.15", features = ["fs"] }
-tokio-util = "0.7"
 tracing-subscriber = "0.3.16"
 
 [dependencies.clap]


### PR DESCRIPTION
The logic used previously was taken from another codebase that had some differences. Instead, the `rebuild` example has been used as inspiration to make the codebase cleaner. This implementation should be equivalent, but does not need to use `tokio-util`'s CancellationToken, nor does it need to use `tokio::select!`.