### PR TITLE
feat(cli): add ability to skip command invocation on startup

### DIFF
--- a/crates/cli/src/commands.rs
+++ b/crates/cli/src/commands.rs
@@ -4,4 +4,8 @@ pub(crate) struct Args {
     pub glob: String,
     pub command: String,
     pub args: Vec<String>,
+
+    #[arg(short, long)]
+    /// If set, the command will not be invoked until the first file change event is received.
+    pub skip_launch_on_startup: bool,
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -50,10 +50,15 @@ async fn main() -> Result<()> {
             .unwrap();
     });
 
-    let mut build_process = tokio::process::Command::new(&args.command)
-        .args(&args.args)
-        .spawn()
-        .ok();
+    let mut build_process = match args.skip_launch_on_startup {
+        true => None,
+        false => Some(
+            tokio::process::Command::new(&args.command)
+                .args(&args.args)
+                .spawn()
+                .expect("failed to spawn child process"),
+        ),
+    };
 
     while let Some(event) = file_events.recv().await {
         match event {


### PR DESCRIPTION
The `-s` or `--skip-launch-on-startup` flag has been added. By default, the command will be invoked right away when `awatch` is launched. If this behavior is not desired, then the flag will ensure it only spawns a child command after a file event has been received.